### PR TITLE
replaces deprecated `Ember.keys` with `Object.keys`

### DIFF
--- a/addon/metrics-adapters/facebook-pixel.js
+++ b/addon/metrics-adapters/facebook-pixel.js
@@ -43,7 +43,7 @@ export default BaseAdapter.extend({
   trackCustom(options={}) {
     const event = options.event;
     const props = without(options, 'event');
-    if (Ember.keys(props).length > 0) {
+    if (Object.keys(props).length > 0) {
       window.fbq('trackCustom', event, props);
     } else {
       window.fbq('trackCustom', event);


### PR DESCRIPTION
Using `Ember.keys` is [deprecated](http://emberjs.com/deprecations/v1.x/#toc_ember-keys) and triggers a warning. `Object.keys` is the recommended way for getting keys of an object.